### PR TITLE
Use latest setup-clojure for setenv deprecation fix

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - fix/setup-clojure
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '13'
-      - uses: DeLaGuardo/setup-clojure@2.0
+      - uses: DeLaGuardo/setup-clojure@master
         with:
           tools-deps: '1.10.1.536'
       - name: Install deps


### PR DESCRIPTION
GitHub Actions have deprecated the setenv command to prevent security
vulnerabilities. This apparently affects the setup-clojure action.
Updating to master might help fix this.

Signed-off-by: Snorre Magnus Davøen <post@snorre.io>