### PR TITLE
feat: View transitions on page navigation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -41,4 +41,7 @@ export default defineConfig({
   markdown: {
     rehypePlugins: [rehypeInferDescriptionMeta, descriptionRemarkPlugin],
   },
+  experimental: {
+    viewTransitions: true
+  }
 });

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -3,6 +3,8 @@
 // all pages through the use of the <BaseHead /> component.
 import '../styles/global.css';
 
+// Enable Astro's built-in support for view transitions
+import { ViewTransitions } from 'astro:transitions';
 
 export interface Props {
 	title: string;
@@ -12,6 +14,9 @@ export interface Props {
 
 const { title, description, image = '/placeholder-social.jpg' } = Astro.props;
 ---
+
+
+<ViewTransitions />
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,6 +4,7 @@ const today = new Date();
 
 <footer class={`
   text-stone-900 dark:text-stone-50
+  bg-stone-200 dark:bg-stone-800
   text-center
   py-8
 `}>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,7 +3,7 @@ import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 
-const { title, description, dir = 'ltr' } = Astro.props;
+const { title, description, dir = 'ltr', page } = Astro.props;
 ---
 
 <html lang="en" class='min-h-full'>
@@ -20,11 +20,12 @@ const { title, description, dir = 'ltr' } = Astro.props;
   </head>
   <body class={`
     min-h-screen
-  bg-stone-200 dark:bg-stone-800
+  bg-stone-50 dark:bg-stone-900
     grid grid-cols-1
     grid-rows-[auto_1fr_auto]`}>
-    <Header />
-    <main class="bg-stone-50 dark:bg-stone-900 h-full flex flex-col">
+    <Header  />
+    <main class="bg-stone-50 dark:bg-stone-900 h-full flex flex-col pt-24"
+    >
       <div
         class={`
           flex flex-row justify-center

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -11,10 +11,12 @@ export interface Props {
     heroImage?: string;
     atprotoURI: string;
   };
+  url: string
 }
 
 const {
   content: { title, description, pubDate, modDate, heroImage, atprotoURI },
+  url
 } = Astro.props;
 
 const dateFormatConfig = {
@@ -27,9 +29,11 @@ const dateFormatConfig = {
 <BaseLayout title={title} description={description}>
     <section
       slot="top"
-      class="pt-24 w-full flex flex-col items-center text-center text-gray-900 dark:text-gray-50"
+      class="w-full flex flex-col items-center text-center text-gray-900 dark:text-gray-50"
     >
-      <h1 class="pb-4 px-4 text-5xl font-shortstack max-w-[25ch]">{title}</h1>
+      <h1
+        class="pb-4 px-4 text-5xl font-shortstack max-w-[25ch]"
+      >{title}</h1>
       {
         pubDate && (
           <time class="text-stone-600 dark:text-stone-400">

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -45,7 +45,8 @@ const posts = (await Astro.glob("./blog/*.{md,mdx}")).sort(
               <h2 class={`
                 text-2xl font-shortstack
                 text-stone-900 dark:text-stone-50
-                underline-stone-900 dark:underline-stone-50`}>
+                underline-stone-900 dark:underline-stone-50`}
+              >
                 {post.frontmatter.title}
               </h2>
               <time


### PR DESCRIPTION
Enable the experimental view transitions support. View transitions are a new web feature, currently supported only in Chromium, that enables the browser to keep around dom elements when doing page navigations. This makes the page look smoother as the user navigates the page.

It also adds support to control how dom elements moves on the page. For example you could morph a title from one page by associating each title with eachother via a transition name. Then a h2 in a list could morph up to become the h1 of the page the user navigates to. Currently I do not use this feature.

It was tested on the blog title in the blog post list and on the blog pages. This looked good when navigating to a blog post page, but looked less than ideal when navigating back to the blog post list.