### PR TITLE
feat: Support continue thread and highlight post

### DIFF
--- a/src/components/comments/Reply.tsx
+++ b/src/components/comments/Reply.tsx
@@ -1,20 +1,18 @@
 import { BskyAgent, RichText } from "@atproto/api";
 import {
-  Accessor,
-  Setter,
+  type Accessor,
+  type Setter,
   Show,
   createEffect,
   createSignal,
-  on,
-  onMount,
 } from "solid-js";
 
 import type { ThreadViewPostUI } from "./utils";
 import { Button } from "./Button";
 
 interface DialogProps {
-  showEditor: Accessor<ThreadViewPostUI | null>;
-  setShowEditor: Setter<ThreadViewPostUI | null>;
+  showEditor: Accessor<ThreadViewPostUI | undefined>;
+  setShowEditor: Setter<ThreadViewPostUI | undefined>;
   agent: Accessor<BskyAgent | undefined>;
   refetch: () => void;
 }
@@ -43,13 +41,13 @@ export const Reply = ({
         // When user clicks outside of dialog, close it
         onClick={(e) => {
           if (e.target === dialog()) {
-            setShowEditor(null);
+            setShowEditor(undefined);
           }
         }}
         // When user presses escape, close it
         onKeyDown={(e) => {
           if (e.key === "Escape") {
-            setShowEditor(null);
+            setShowEditor(undefined);
           }
         }}
         ref={(el) => setDialog(el)}
@@ -85,7 +83,7 @@ export const Reply = ({
                 },
               });
               await refetch();
-              setShowEditor(null);
+              setShowEditor(undefined);
             }
           }}
         >
@@ -109,7 +107,7 @@ export const Reply = ({
             onCut={(e) => setEditorText(new RichText({ text: "" }))}
           />
           <div class="flex flex-row gap-2 w-full justify-between">
-            <Button type="button" onClick={() => setShowEditor(null)}>
+            <Button type="button" onClick={() => setShowEditor(undefined)}>
               Nevermind
             </Button>
             <Button type="submit">Share thoughts</Button>

--- a/src/components/comments/utils.ts
+++ b/src/components/comments/utils.ts
@@ -58,22 +58,20 @@ function addThreadUIData(
   walkChildren = true,
   walkParent = true,
 ): ThreadViewPostUI {
-  let parent = threadViewPost.parent;
-  if (walkParent && AppBskyFeedDefs.isFeedViewPost(threadViewPost.parent)) {
+  let parent
+  if (walkParent && AppBskyFeedDefs.isThreadViewPost(threadViewPost.parent)) {
     // Recursively add UI data to parent
-    const newParent = {
+    parent = addThreadUIData({
       ...threadViewPost.parent,
-      showParentReplyLine: false,
-      showChildReplyLine: false,
+      showParentReplyLine: threadViewPost.parent?.parent? true : false,
+      showChildReplyLine: true,
       isHighlightedPost: false,
-    } satisfies ThreadViewPostUI;
-    threadViewPost.parent = newParent;
-    addThreadUIData(newParent, (walkChildren = false), (walkParent = true));
+    }, false, true);
   }
 
   let replies: ThreadViewPostUI[] = [];
-  if (walkChildren && threadViewPost.replies?.length) {
-    replies = threadViewPost.replies
+  if (walkChildren && (threadViewPost.replies?.length?? 0) > 0) {
+    replies = threadViewPost.replies!
       .map((reply) => {
         if (AppBskyFeedDefs.isThreadViewPost(reply)) {
           // Recursively add UI data to children
@@ -85,12 +83,14 @@ function addThreadUIData(
             showChildReplyLine:
               (reply?.replies?.length ?? 0) > 0 ? true : false,
             isHighlightedPost: false,
-          } satisfies ThreadViewPostUI);
+          } satisfies ThreadViewPostUI,
+            true,
+            false);
         }
-        return undefined;
       })
       .filter((x): x is ThreadViewPostUI => x !== undefined);
   }
+
 
   return { ...threadViewPost, parent, replies };
 }


### PR DESCRIPTION
There is a limit to how many children are fetched using the Bluesky client. Whenever we reach the limit, i.e. the reply count indicates more replies, but the reply list is empty, we show a "continue thread" button to allow readers to show more comments. This highlights the last reply and shows replies under that post.

Each post header (avatar, display name, etc) is a button which allows users to highlight that post. This is useful if you want to reduce the part of the thread tree that you are looking at.

Note that the parentHeight limit is now set to 20. This makes it so that up to 20 parent posts are fetched allowing readers to view most of the parents for a highlighted post. In extreme cases where the depth of a thread is more than 20 some parents are not returned. This is acceptable.

Fix #35.