### PR TITLE
fix: Content jumps because of inconsistent scrollbar

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -43,5 +43,9 @@ const { title, description, image = "./index-og.png" } = Astro.props;
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
 
-
-
+<!-- Global style -->
+ <style>
+html {
+  overflow-y: scroll;
+}
+ </style>


### PR DESCRIPTION
Because some pages have scrollbars and some don't the content appear to jump. This is especially noticeable because the site uses browser native transitions to not re-render the entire page. Because there is no visible reload flash, the content can be observed more directly jumping.

Added overflow-y scroll to the html element to always show a scrollbar. This ensures the viewport is the same width on all pages.