### PR TITLE
fix: Add sitemap link to head element

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -23,6 +23,9 @@ const { title, description, image = "./index-og.png" } = Astro.props;
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
 
+<!-- Sitemap located on non-standard path -->
+<link rel="sitemap" href="/sitemap-index.xml" />
+
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>


### PR DESCRIPTION
As Astro sitemap integration adds sitemap to non-standard location we need to add it to head.